### PR TITLE
Enhance visuals with materials and history context

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
       <p class="panel-description">Set how quickly cumulative production grows. Wright's law works on the number of doublings from today's baseline.</p>
       <div class="control-group">
         <label for="startYear">Baseline year</label>
-        <input type="number" id="startYear" value="2024" min="2000" max="2100">
+        <input type="number" id="startYear" value="2024" min="2024" max="2100">
       </div>
       <div class="control-group">
         <label for="forecastYears">Forecast horizon <span class="value" data-target="forecastYears"></span></label>
@@ -63,7 +63,37 @@
           <h2>Cost trajectory</h2>
           <p class="card-subtitle">Smoothed Wright's law with a materials floor. Hover to inspect annual values.</p>
         </div>
-        <canvas id="costChart" height="340"></canvas>
+        <div class="chart-container">
+          <canvas id="costChart"></canvas>
+        </div>
+      </div>
+      <div class="card materials-card">
+        <div class="card-header">
+          <h2>Baseline vs materials floor</h2>
+          <p class="card-subtitle">Compare today's pack prices with materials-derived floors.</p>
+        </div>
+        <div class="chart-container compact">
+          <canvas id="materialsChart"></canvas>
+        </div>
+      </div>
+      <div class="card table-card history-card">
+        <div class="card-header">
+          <h2>Historical cost decline</h2>
+          <p class="card-subtitle">Observed pack prices through 2024 (BloombergNEF, industry disclosures).</p>
+        </div>
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Year</th>
+                <th>LFP</th>
+                <th>NMC-811</th>
+                <th>Sodium-ion</th>
+              </tr>
+            </thead>
+            <tbody id="historyTable"></tbody>
+          </table>
+        </div>
       </div>
       <div class="card table-card">
         <div class="card-header">

--- a/styles.css
+++ b/styles.css
@@ -344,6 +344,13 @@ body::before {
   color: var(--positive);
 }
 
+.summary-card .meta {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
 .card {
   background: var(--card-bg);
   border-radius: 22px;
@@ -361,6 +368,21 @@ body::before {
   color: var(--muted);
   font-size: 0.9rem;
   margin: 0.35rem 0 0;
+}
+
+.chart-container {
+  position: relative;
+  width: 100%;
+  height: 360px;
+}
+
+.chart-container.compact {
+  height: 260px;
+}
+
+.chart-container canvas {
+  width: 100% !important;
+  height: 100% !important;
 }
 
 .table-wrapper {
@@ -399,6 +421,36 @@ td:first-child {
   font-family: "Space Grotesk", monospace;
 }
 
+.materials-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.materials-card .chart-container {
+  height: 300px;
+}
+
+.history-card table tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.history-card td {
+  font-variant-numeric: tabular-nums;
+}
+
+.history-card td:not(:first-child) {
+  color: rgba(243, 244, 246, 0.9);
+}
+
+.history-card td:nth-child(1) {
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.history-card td.empty {
+  color: rgba(148, 163, 184, 0.6);
+}
+
 footer {
   max-width: 1200px;
   margin: 0 auto;
@@ -435,5 +487,13 @@ footer {
 
   th, td {
     font-size: 0.85rem;
+  }
+
+  .chart-container {
+    height: 280px;
+  }
+
+  .materials-card .chart-container {
+    height: 220px;
   }
 }


### PR DESCRIPTION
## Summary
- add dedicated cards for materials cost comparison and historical pack pricing
- extend the cost trajectory chart to show observed history with styled segments and updated summaries
- adjust layout styles to stabilize chart sizing and surface materials floor data in summaries

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cb456f4ea483228f7213ad2df3d616